### PR TITLE
migrate to OpenBSD 6.3+ interface (promises and execpromises)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,20 @@ A Rust binding to OpenBSD's pledge(2) interface.
     use pledge::{pledge, Promise, ToPromiseString};
 
     fn foo() {
-        match pledge![Stdio, RPath] {
+        // make both promises and execpromises
+        match pledge![Stdio Proc Exec, Stdio Tty] {
+            Err(_) => println!("Failed to pledge"),
+            _ => ()
+        }
+
+        // make promises only
+        match pledge_promises[Stdio Exec] {
+            Err(_) => println!("Failed to pledge"),
+            _ => ()
+        }
+
+        // make execpromises only
+        match pledge_execpromises[Stdio] {
             Err(_) => println!("Failed to pledge"),
             _ => ()
         }
@@ -23,7 +36,24 @@ This is equivalent to:
     use pledge::{pledge, Promise, ToPromiseString};
 
     fn foo() {
-        match pledge(&vec![Promise::Stdio, Promise::RPath].to_promise_string()) {
+        // make both promises and execpromises
+        let promises = vec![Promise::Stdio, Promise::Proc, Promise::Exec];
+        let execpromises = vec![Promise::Stdio, Promise::Tty];
+        match pledge(&*promises.to_promise_string(), &*execpromises.to_promise_string()) {
+            Err(_) => println!("Failed to pledge"),
+            _ => ()
+        }
+
+        // make promises only
+        let promises = vec![Promise::Stdio, Promise::Exec];
+        match pledge(&*promises.to_promise_string(), None) {
+            Err(_) => println!("Failed to pledge"),
+            _ => ()
+        }
+
+        // make execpromises only
+        let execpromises = vec![Promise::Stdio];
+        match pledge(None, &*execpromises.to_promise_string()) {
             Err(_) => println!("Failed to pledge"),
             _ => ()
         }
@@ -34,7 +64,40 @@ You may also provide promises directly as a string:
     use pledge::pledge;
 
     fn foo() {
-        if pledge("stdio rpath").is_err() {
+        // make both promises and execpromises
+        if pledge("stdio proc exec", "stdio tty").is_err() {
+            panic!("Failed to pledge");
+        }
+
+        // make promises only
+        if pledge("stdio exec", None).is_err() {
+            panic!("Failed to pledge");
+        }
+
+        // make execpromises only
+        if pledge(None, "stdio").is_err() {
             panic!("Failed to pledge");
         }
     }
+
+## Compatibility
+
+This version of the crate is compatible with the [OpenBSD 6.3+ interface], where
+the second parameter restricts the privileges of the process after execve(2).
+
+Use version `^0.3` for the [OpenBSD 5.9+ interface] last supported by [Bitrig],
+where the second parameter sets a whitelist of permitted paths.
+
+To migrate your code from older versions:
+
+* change `pledge![P, Q, R]` call sites to `pledge_promises![P, Q, R]`
+* change `pledge("p q r")` call sites to `pledge("p q r", None)`
+* change `pledge_with_paths(promises, paths)` to `pledge(promises)`
+* consider making execpromises to restrict processes after execve(2)
+* consider using [unveil(2)] and the [unveil crate] (OpenBSD 6.4+)
+
+[OpenBSD 6.3+ interface]: https://man.openbsd.org/OpenBSD-6.3/pledge.2
+[OpenBSD 5.9+ interface]: https://man.openbsd.org/OpenBSD-5.9/pledge.2
+[Bitrig]: https://www.bitrig.org
+[unveil(2)]: https://man.openbsd.org/OpenBSD-6.4/unveil.2
+[unveil crate]: https://crates.io/crates/unveil

--- a/src/openbsd.rs
+++ b/src/openbsd.rs
@@ -2,37 +2,33 @@ extern crate libc;
 
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int};
-use std::os::unix::ffi::OsStrExt;
-use std::path;
 use std::ptr;
 
 use Error;
 
-pub fn pledge_with_paths(promises: &str, paths: &[&path::Path]) -> Result<(), Error> {
+pub fn pledge<'p, 'e, P, E>(promises: P, execpromises: E) -> Result<(), Error>
+where P: Into<Option<&'p str>>, E: Into<Option<&'e str>> {
     extern "C" {
-        fn pledge(promises: *const c_char, paths: *const *const c_char) -> c_int;
+        fn pledge(promises: *const c_char, execpromises: *const c_char) -> c_int;
     }
 
-    let cstr = CString::new(promises).unwrap();
-    let mut cpaths = Vec::with_capacity(paths.len());
-    for path in paths {
-        cpaths.push(CString::new(path.as_os_str().as_bytes()).unwrap());
-    }
-
-    let mut cpaths_raw = cpaths
-        .iter()
-        .map(|path| path.as_ptr())
-        .collect::<Vec<*const libc::c_char>>();
+    let promises = promises.into().map(|x| CString::new(x).map_err(Error::Promises));
+    let execpromises = execpromises.into().map(|x| CString::new(x).map_err(Error::Execpromises));
 
     unsafe {
-        let cpaths_ptr = if !cpaths.is_empty() {
-            cpaths_raw.push(ptr::null());
-            cpaths_raw.as_ptr()
-        } else {
-            ptr::null()
-        };
+        let promises = match promises {
+            Some(Ok(ref result)) => Ok(result.as_ptr()),
+            Some(Err(error)) => Err(error),
+            None => Ok(ptr::null()),
+        }?;
 
-        return match pledge(cstr.as_ptr(), cpaths_ptr) {
+        let execpromises = match execpromises {
+            Some(Ok(ref result)) => Ok(result.as_ptr()),
+            Some(Err(error)) => Err(error),
+            None => Ok(ptr::null()),
+        }?;
+
+        return match pledge(promises, execpromises) {
             0 => Ok(()),
             _ => Err(Error::Other(*libc::__errno())),
         };


### PR DESCRIPTION
OpenBSD 6.3 [changes the second parameter](https://man.openbsd.org/OpenBSD-6.3/pledge.2) to `const char *execpromises`, later reintroducing path whitelisting as [unveil(2)](https://man.openbsd.org/OpenBSD-6.4/unveil.2).

Before this pull request, our old API was:

- `pledge![$($:ident),*]`
- `pledge(&str) -> Result<(), Error>`
- `pledge_with_paths(&str, &[&Path]) -> Result<(), Error>`

Given types P and E that impl `Into<Option<&str>>`, it will become:

- `pledge![$($:ident)*, $($:ident)*]`
- `pledge_promises![$($:ident)*]`
- `pledge_execpromises![$($:ident)*]`
- `pledge(P, E) -> Result<(), Error>`

The new interface lets callers pass NULL to either of the arguments by using `pledge_promises![]`, using `pledge_execpromises![]`, or calling `pledge(P, E)` with one or both arguments set to None. This isn’t the same as `pledge("", "")`, and it’s especially important for programs that want to make promises without making any execpromises.

This is a breaking change. We could adopt the new pledge(2) without breaking changes (add a `pledge_new` function, then make both `pledge(p)` and `pledge_with_paths(p, q)` call `pledge_new(p, None)`, because the old path whitelisting API [was never implemented](https://man.openbsd.org/OpenBSD-6.2/pledge.2#BUGS)), but this is a good time to keep our API clean and remind consumers to also unveil(2).

I’ve tested this on Linux and OpenBSD 6.5.